### PR TITLE
Fix - update apt cache before installing java

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,3 +14,4 @@
   apt:
     name: "{{ java_packages }}"
     state: present
+    update_cache : true


### PR DESCRIPTION
Fix - ansible fails on ubuntu 22 image if apt cache has never been updated